### PR TITLE
Fix RPM packaging: sysconfdir path and container-aware mock detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,9 @@ if(VC_BUILD_BENCHMARKS)
 endif()
 
 # Installation
+# Override GNUInstallDirs default of "etc" (relative to prefix, giving /usr/etc)
+# System config files belong in /etc, not /usr/etc
+set(CMAKE_INSTALL_SYSCONFDIR /etc CACHE PATH "System configuration directory")
 include(GNUInstallDirs)
 
 # Binaries

--- a/packaging/build-rpm.sh
+++ b/packaging/build-rpm.sh
@@ -24,19 +24,29 @@ cp vigilant-canine.spec ~/rpmbuild/SPECS/
 # Build SRPM
 rpmbuild -bs ~/rpmbuild/SPECS/vigilant-canine.spec
 
-# Build RPM (or use mock for clean environment)
-if command -v mock &> /dev/null; then
+# Detect container environment (distrobox, docker, podman) where mock cannot nest containers
+in_container() {
+    [ -f /run/.containerenv ] || [ -f /.dockerenv ] || [ -n "${container:-}" ]
+}
+
+# Build RPM (or use mock for clean environment, unless inside a container)
+if command -v mock &> /dev/null && ! in_container; then
     echo "Building with mock for clean environment..."
     mock -r fedora-$(rpm -E %fedora)-$(uname -m) \
         ~/rpmbuild/SRPMS/vigilant-canine-$VERSION-*.src.rpm
+    MOCK_USED=1
 else
-    echo "Building with rpmbuild (install 'mock' for cleaner builds)..."
+    if in_container; then
+        echo "Container environment detected — skipping mock (nested containers not supported)."
+    fi
+    echo "Building with rpmbuild..."
     rpmbuild -bb ~/rpmbuild/SPECS/vigilant-canine.spec
+    MOCK_USED=0
 fi
 
 echo "Build complete!"
 echo "SRPM: ~/rpmbuild/SRPMS/vigilant-canine-$VERSION-*.src.rpm"
-if command -v mock &> /dev/null; then
+if [ "${MOCK_USED:-0}" = "1" ]; then
     echo "RPM: /var/lib/mock/fedora-$(rpm -E %fedora)-$(uname -m)/result/*.rpm"
 else
     echo "RPM: ~/rpmbuild/RPMS/*/vigilant-canine-*.rpm"


### PR DESCRIPTION
## Summary

- **Fix `CMAKE_INSTALL_SYSCONFDIR`**: `GNUInstallDirs` defaults this to `etc` (relative to prefix), causing config files to install to `/usr/etc/vigilant-canine/` instead of `/etc/vigilant-canine/`. Set it to `/etc` (absolute) before `include(GNUInstallDirs)` so the RPM `%files` section can find `config.toml.example`.
- **Container-aware mock detection in `build-rpm.sh`**: Mock cannot run inside containers (distrobox, Docker, Podman). Added `in_container()` helper to detect container environments and fall back to `rpmbuild` automatically. Also tracks `MOCK_USED` flag to show the correct output path at the end.

## Test plan

- [ ] Run `packaging/build-rpm.sh` on a bare Fedora host — should use mock
- [ ] Run `packaging/build-rpm.sh` inside a distrobox/container — should skip mock and use rpmbuild directly
- [ ] Verify `config.toml.example` lands in `/etc/vigilant-canine/` in the installed RPM

🤖 Generated with [Claude Code](https://claude.com/claude-code)